### PR TITLE
aio: windows: fix initialization error in ovlOff

### DIFF
--- a/src/aio/Windows.zig
+++ b/src/aio/Windows.zig
@@ -215,12 +215,9 @@ fn onThreadTimeout(ctx: *anyopaque, user_data: usize) void {
 }
 
 fn ovlOff(offset: u64) io.OVERLAPPED {
-    return .{
-        .Internal = undefined,
-        .InternalHigh = undefined,
-        .Anonymous = .{ .Anonymous = @bitCast(offset) },
-        .hEvent = undefined,
-    };
+    var result = std.mem.zeroes(io.OVERLAPPED);
+    result.Anonymous = .{ .Anonymous = @bitCast(offset) };
+    return result;
 }
 
 const AccessInfo = packed struct {


### PR DESCRIPTION
This PR fixes a segfault that occurred on Windows when attempting to run the `aio_dynamic.zig` and `aio_immediate.zig` examples. This segafault was occurring because of a failure to initialize the OVERLAPPED structs associated with the I/O operations. According to the Windows documentation this struct needs to be zero initialized before it is used in any API calls. This PR simply changes the initialization function `ovlOff` to properly zero initialize the structs.