### PR TITLE
fix "undefined symbol: zefi_stack_swap"

### DIFF
--- a/src/coro/zefi.zig
+++ b/src/coro/zefi.zig
@@ -142,6 +142,9 @@ extern fn zefi_stack_swap(
     noalias current_context_ptr: **anyopaque,
     noalias new_context_ptr: **anyopaque,
 ) void;
+comptime {
+    asm (StackContext.assembly);
+}
 
 const StackContext = switch (builtin.cpu.arch) {
     .x86_64 => switch (builtin.os.tag) {
@@ -157,64 +160,62 @@ const Intel_Microsoft = struct {
 
     pub const entry_offset = word_count - 1;
 
-    comptime {
-        asm (
-            \\.global zefi_stack_swap
-            \\zefi_stack_swap:
-            \\  pushq %gs:0x10
-            \\  pushq %gs:0x08
-            \\
-            \\  pushq %rbx
-            \\  pushq %rbp
-            \\  pushq %rdi
-            \\  pushq %rsi
-            \\  pushq %r12
-            \\  pushq %r13
-            \\  pushq %r14
-            \\  pushq %r15
-            \\
-            \\  subq $160, %rsp
-            \\  movups %xmm6, 0x00(%rsp)
-            \\  movups %xmm7, 0x10(%rsp)
-            \\  movups %xmm8, 0x20(%rsp)
-            \\  movups %xmm9, 0x30(%rsp)
-            \\  movups %xmm10, 0x40(%rsp)
-            \\  movups %xmm11, 0x50(%rsp)
-            \\  movups %xmm12, 0x60(%rsp)
-            \\  movups %xmm13, 0x70(%rsp)
-            \\  movups %xmm14, 0x80(%rsp)
-            \\  movups %xmm15, 0x90(%rsp)
-            \\
-            \\  movq %rsp, (%rcx)
-            \\  movq (%rdx), %rsp
-            \\
-            \\  movups 0x00(%rsp), %xmm6
-            \\  movups 0x10(%rsp), %xmm7
-            \\  movups 0x20(%rsp), %xmm8
-            \\  movups 0x30(%rsp), %xmm9
-            \\  movups 0x40(%rsp), %xmm10
-            \\  movups 0x50(%rsp), %xmm11
-            \\  movups 0x60(%rsp), %xmm12
-            \\  movups 0x70(%rsp), %xmm13
-            \\  movups 0x80(%rsp), %xmm14
-            \\  movups 0x90(%rsp), %xmm15
-            \\  addq $160, %rsp
-            \\
-            \\  popq %r15
-            \\  popq %r14
-            \\  popq %r13
-            \\  popq %r12
-            \\  popq %rsi
-            \\  popq %rdi
-            \\  popq %rbp
-            \\  popq %rbx
-            \\
-            \\  popq %gs:0x08
-            \\  popq %gs:0x10
-            \\
-            \\  retq
-        );
-    }
+    pub const assembly =
+        \\.global zefi_stack_swap
+        \\zefi_stack_swap:
+        \\  pushq %gs:0x10
+        \\  pushq %gs:0x08
+        \\
+        \\  pushq %rbx
+        \\  pushq %rbp
+        \\  pushq %rdi
+        \\  pushq %rsi
+        \\  pushq %r12
+        \\  pushq %r13
+        \\  pushq %r14
+        \\  pushq %r15
+        \\
+        \\  subq $160, %rsp
+        \\  movups %xmm6, 0x00(%rsp)
+        \\  movups %xmm7, 0x10(%rsp)
+        \\  movups %xmm8, 0x20(%rsp)
+        \\  movups %xmm9, 0x30(%rsp)
+        \\  movups %xmm10, 0x40(%rsp)
+        \\  movups %xmm11, 0x50(%rsp)
+        \\  movups %xmm12, 0x60(%rsp)
+        \\  movups %xmm13, 0x70(%rsp)
+        \\  movups %xmm14, 0x80(%rsp)
+        \\  movups %xmm15, 0x90(%rsp)
+        \\
+        \\  movq %rsp, (%rcx)
+        \\  movq (%rdx), %rsp
+        \\
+        \\  movups 0x00(%rsp), %xmm6
+        \\  movups 0x10(%rsp), %xmm7
+        \\  movups 0x20(%rsp), %xmm8
+        \\  movups 0x30(%rsp), %xmm9
+        \\  movups 0x40(%rsp), %xmm10
+        \\  movups 0x50(%rsp), %xmm11
+        \\  movups 0x60(%rsp), %xmm12
+        \\  movups 0x70(%rsp), %xmm13
+        \\  movups 0x80(%rsp), %xmm14
+        \\  movups 0x90(%rsp), %xmm15
+        \\  addq $160, %rsp
+        \\
+        \\  popq %r15
+        \\  popq %r14
+        \\  popq %r13
+        \\  popq %r12
+        \\  popq %rsi
+        \\  popq %rdi
+        \\  popq %rbp
+        \\  popq %rbx
+        \\
+        \\  popq %gs:0x08
+        \\  popq %gs:0x10
+        \\
+        \\  retq
+    ;
 };
 
 const symbol = switch (builtin.target.os.tag) {
@@ -227,30 +228,29 @@ const Intel_SysV = struct {
 
     pub const entry_offset = word_count - 1;
 
-    comptime {
-        asm (std.fmt.comptimePrint(
-                \\.global {[symbol]s}
-                \\{[symbol]s}:
-                \\  pushq %rbx
-                \\  pushq %rbp
-                \\  pushq %r12
-                \\  pushq %r13
-                \\  pushq %r14
-                \\  pushq %r15
-                \\
-                \\  movq %rsp, (%rdi)
-                \\  movq (%rsi), %rsp
-                \\
-                \\  popq %r15
-                \\  popq %r14
-                \\  popq %r13
-                \\  popq %r12
-                \\  popq %rbp
-                \\  popq %rbx
-                \\
-                \\  retq
-            , .{ .symbol = symbol }));
-    }
+    pub const assembly =
+        std.fmt.comptimePrint(
+        \\.global {[symbol]s}
+        \\{[symbol]s}:
+        \\  pushq %rbx
+        \\  pushq %rbp
+        \\  pushq %r12
+        \\  pushq %r13
+        \\  pushq %r14
+        \\  pushq %r15
+        \\
+        \\  movq %rsp, (%rdi)
+        \\  movq (%rsi), %rsp
+        \\
+        \\  popq %r15
+        \\  popq %r14
+        \\  popq %r13
+        \\  popq %r12
+        \\  popq %rbp
+        \\  popq %rbx
+        \\
+        \\  retq
+    , .{ .symbol = symbol });
 };
 
 const Arm_64 = struct {
@@ -258,38 +258,37 @@ const Arm_64 = struct {
 
     pub const entry_offset = 0;
 
-    comptime {
-        asm (std.fmt.comptimePrint(
-                \\.global {[symbol]s}
-                \\{[symbol]s}:
-                \\  stp lr, fp, [sp, #-20*8]!
-                \\  stp d8, d9, [sp, #2*8]
-                \\  stp d10, d11, [sp, #4*8]
-                \\  stp d12, d13, [sp, #6*8]
-                \\  stp d14, d15, [sp, #8*8]
-                \\  stp x19, x20, [sp, #10*8]
-                \\  stp x21, x22, [sp, #12*8]
-                \\  stp x23, x24, [sp, #14*8]
-                \\  stp x25, x26, [sp, #16*8]
-                \\  stp x27, x28, [sp, #18*8]
-                \\
-                \\  mov x9, sp
-                \\  str x9, [x0]
-                \\  ldr x9, [x1]
-                \\  mov sp, x9
-                \\
-                \\  ldp x27, x28, [sp, #18*8]
-                \\  ldp x25, x26, [sp, #16*8]
-                \\  ldp x23, x24, [sp, #14*8]
-                \\  ldp x21, x22, [sp, #12*8]
-                \\  ldp x19, x20, [sp, #10*8]
-                \\  ldp d14, d15, [sp, #8*8]
-                \\  ldp d12, d13, [sp, #6*8]
-                \\  ldp d10, d11, [sp, #4*8]
-                \\  ldp d8, d9, [sp, #2*8]
-                \\  ldp lr, fp, [sp], #20*8
-                \\
-                \\  ret
-            , .{ .symbol = symbol }));
-    }
+    pub const assembly =
+        std.fmt.comptimePrint(
+        \\.global {[symbol]s}
+        \\{[symbol]s}:
+        \\  stp lr, fp, [sp, #-20*8]!
+        \\  stp d8, d9, [sp, #2*8]
+        \\  stp d10, d11, [sp, #4*8]
+        \\  stp d12, d13, [sp, #6*8]
+        \\  stp d14, d15, [sp, #8*8]
+        \\  stp x19, x20, [sp, #10*8]
+        \\  stp x21, x22, [sp, #12*8]
+        \\  stp x23, x24, [sp, #14*8]
+        \\  stp x25, x26, [sp, #16*8]
+        \\  stp x27, x28, [sp, #18*8]
+        \\
+        \\  mov x9, sp
+        \\  str x9, [x0]
+        \\  ldr x9, [x1]
+        \\  mov sp, x9
+        \\
+        \\  ldp x27, x28, [sp, #18*8]
+        \\  ldp x25, x26, [sp, #16*8]
+        \\  ldp x23, x24, [sp, #14*8]
+        \\  ldp x21, x22, [sp, #12*8]
+        \\  ldp x19, x20, [sp, #10*8]
+        \\  ldp d14, d15, [sp, #8*8]
+        \\  ldp d12, d13, [sp, #6*8]
+        \\  ldp d10, d11, [sp, #4*8]
+        \\  ldp d8, d9, [sp, #2*8]
+        \\  ldp lr, fp, [sp], #20*8
+        \\
+        \\  ret
+    , .{ .symbol = symbol });
 };


### PR DESCRIPTION
This seems to fix this error on my machine (running Gentoo Linux, Zig 0.13.0), and it looks a bit cleaner IMO