### PR TITLE
coro.Semaphore: fix deadlock

### DIFF
--- a/src/coro/Sync.zig
+++ b/src/coro/Sync.zig
@@ -18,6 +18,7 @@ pub const Semaphore = struct {
         if (Frame.current()) |frame| {
             if (frame.canceled) return error.Canceled;
             self.counter += 1;
+            if (self.counter == 1) return;
             self.waiters.prepend(&frame.wait_link);
             defer self.waiters.remove(&frame.wait_link);
             while (self.counter > 0 and !frame.canceled) Frame.yield(.semaphore);


### PR DESCRIPTION
I've noticed that Semaphore is infinitely waiting for someone to unlock because the first locking case isn't implemented.
Which is making a deadlock alone by itself.