### PR TITLE
semaphore deadlocks with multiple tasks

### DIFF
--- a/src/coro/Sync.zig
+++ b/src/coro/Sync.zig
@@ -17,7 +17,7 @@ pub const Semaphore = struct {
     pub fn lock(self: *@This()) Error!void {
         if (Frame.current()) |frame| {
             if (frame.canceled) return error.Canceled;
-            
+
             if (!self.used) {
                 self.used = true;
                 return;

--- a/src/coro/Sync.zig
+++ b/src/coro/Sync.zig
@@ -10,25 +10,37 @@ fn wakeupWaiters(list: *Frame.WaitList, status: anytype) void {
 
 pub const Semaphore = struct {
     waiters: Frame.WaitList = .{},
-    counter: u32 = 0,
+    used: bool = false,
 
     pub const Error = error{Canceled};
 
     pub fn lock(self: *@This()) Error!void {
         if (Frame.current()) |frame| {
             if (frame.canceled) return error.Canceled;
-            self.counter += 1;
-            if (self.counter == 1) return;
+            
+            if (!self.used) {
+                self.used = true;
+                return;
+            }
+
             self.waiters.prepend(&frame.wait_link);
             defer self.waiters.remove(&frame.wait_link);
-            while (self.counter > 0 and !frame.canceled) Frame.yield(.semaphore);
+
+            while (!frame.canceled) {
+                Frame.yield(.semaphore);
+                if (!self.used) {
+                    self.used = true;
+                    break;
+                }
+            }
+
             if (frame.canceled) return error.Canceled;
         } else unreachable; // can only be used in tasks
     }
 
     pub fn unlock(self: *@This()) void {
-        if (self.counter == 0) return;
-        self.counter -= 1;
+        if (!self.used) return;
+        self.used = false;
         wakeupWaiters(&self.waiters, .semaphore);
     }
 };


### PR DESCRIPTION
I've noticed that in the current condition of the "waiting loop" is to wait for the counter to be 0, however this condition isn't possible if there's more than one task. So I rewrited the semaphore in order to prevent a situation where a task is undefinitely yielding even if the semaphore was unlocked.

The patern is simple: if the semaphore is lock wait until it isn't, and lock it and return. A counter is totally useless in such a structure.

NOTE: I think it would be better to only wakeup one task. I didn't changed that as my pull request isn't about that.