### PR TITLE
coro: add thread-safe mutex and rwlock primitives

### DIFF
--- a/src/coro/sync.zig
+++ b/src/coro/sync.zig
@@ -1,3 +1,6 @@
+const std = @import("std");
+const aio = @import("aio");
+const coro = @import("../coro.zig");
 const Frame = @import("Frame.zig");
 
 fn wakeupWaiters(list: *Frame.WaitList, status: anytype) void {
@@ -73,3 +76,372 @@ pub const ResetEvent = struct {
         self.is_set = false;
     }
 };
+
+/// A thread-safe Mutex implemented on top of aio.EventSource
+/// When the mutex is locked other tasks can still run
+const Mutex = struct {
+    native: std.Thread.Mutex = .{},
+    semaphore: aio.EventSource,
+
+    pub fn init() !@This() {
+        return .{ .semaphore = try aio.EventSource.init() };
+    }
+
+    pub fn deinit(self: *@This()) void {
+        self.semaphore.deinit();
+    }
+
+    pub fn tryLock(self: *@This()) bool {
+        return self.native.tryLock();
+    }
+
+    pub fn lock(self: *@This()) !void {
+        if (Frame.current()) |frame| {
+            if (frame.canceled) return error.Canceled;
+            while (!self.tryLock()) {
+                try coro.io.single(.wait_event_source, .{
+                    .source = &self.semaphore,
+                });
+            }
+        } else {
+            while (!self.tryLock()) {
+                self.semaphore.wait();
+            }
+        }
+    }
+
+    pub fn unlock(self: *@This()) void {
+        self.native.unlock();
+        self.semaphore.notify();
+    }
+};
+
+/// A thread-safe RwLock implemented on top of coro.Mutex
+/// When the RwLock is locked other tasks can still run
+pub const RwLock = struct {
+    state: usize = 0,
+    mutex: Mutex,
+    semaphore: aio.EventSource,
+    locking_thread: std.atomic.Value(std.Thread.Id) = std.atomic.Value(std.Thread.Id).init(0),
+
+    pub fn init() !@This() {
+        return .{
+            .mutex = try Mutex.init(),
+            .semaphore = try aio.EventSource.init(),
+        };
+    }
+
+    pub fn deinit(self: *@This()) void {
+        self.mutex.deinit();
+        self.semaphore.deinit();
+    }
+
+    const IS_WRITING: usize = 1;
+    const WRITER: usize = 1 << 1;
+    const READER: usize = 1 << (1 + @bitSizeOf(Count));
+    const WRITER_MASK: usize = std.math.maxInt(Count) << @ctz(WRITER);
+    const READER_MASK: usize = std.math.maxInt(Count) << @ctz(READER);
+    const Count = std.meta.Int(.unsigned, @divFloor(@bitSizeOf(usize) - 1, 2));
+
+    pub fn lock(rwl: *@This()) !void {
+        _ = @atomicRmw(usize, &rwl.state, .Add, WRITER, .seq_cst);
+        try rwl.mutex.lock();
+        rwl.locking_thread.store(std.Thread.getCurrentId(), .unordered);
+
+        while (true) {
+            const state = @atomicRmw(usize, &rwl.state, .Add, IS_WRITING -% WRITER, .seq_cst);
+            if (state & READER_MASK == 0) break;
+            try coro.io.single(.wait_event_source, .{
+                .source = &rwl.semaphore,
+            });
+        }
+    }
+
+    pub fn unlock(rwl: *@This()) void {
+        _ = @atomicRmw(usize, &rwl.state, .And, ~IS_WRITING, .seq_cst);
+        rwl.locking_thread.store(0, .unordered);
+        rwl.mutex.unlock();
+    }
+
+    pub fn lockShared(rwl: *@This()) !void {
+        while (rwl.locking_thread.load(.unordered) == std.Thread.getCurrentId()) {
+            try rwl.mutex.lock();
+            rwl.mutex.unlock();
+        }
+
+        var state = @atomicLoad(usize, &rwl.state, .seq_cst);
+        while (state & (IS_WRITING | WRITER_MASK) == 0) {
+            state = @cmpxchgWeak(
+                usize,
+                &rwl.state,
+                state,
+                state + READER,
+                .seq_cst,
+                .seq_cst,
+            ) orelse return;
+        }
+
+        try rwl.mutex.lock();
+        _ = @atomicRmw(usize, &rwl.state, .Add, READER, .seq_cst);
+        rwl.mutex.unlock();
+    }
+
+    pub fn unlockShared(rwl: *@This()) void {
+        if (rwl.locking_thread.load(.unordered) == std.Thread.getCurrentId()) {
+            @panic("RwLock: unlockShared while locked by the same thread");
+        }
+
+        const state = @atomicRmw(usize, &rwl.state, .Sub, READER, .seq_cst);
+
+        if ((state & READER_MASK == READER) and (state & IS_WRITING != 0))
+            rwl.semaphore.notify();
+    }
+};
+
+test "Mutex" {
+    const Test = struct {
+        fn incrementer(lock: *Mutex, value: *usize) !void {
+            try lock.lock();
+            defer lock.unlock();
+
+            const stored = value.*;
+
+            // simulates a "workload"
+            try coro.io.single(.timeout, .{ .ns = std.time.ns_per_ms });
+
+            value.* = stored + 1000;
+        }
+
+        fn test_thread(lock: *Mutex, value: *usize) !void {
+            var scheduler = try coro.Scheduler.init(std.testing.allocator, .{});
+            defer scheduler.deinit();
+
+            for (0..128) |_| {
+                _ = try scheduler.spawn(incrementer, .{ lock, value }, .{ .detached = true });
+            }
+
+            try scheduler.run(.wait);
+        }
+    };
+
+    var lock = try Mutex.init();
+    defer lock.deinit();
+
+    var value: usize = 0;
+
+    var threads: [8]std.Thread = undefined;
+
+    for (0..8) |i| {
+        threads[i] = try std.Thread.spawn(.{}, Test.test_thread, .{ &lock, &value });
+    }
+
+    for (threads) |thread| {
+        thread.join();
+    }
+
+    try std.testing.expectEqual(value, 1024000);
+}
+
+test "RwLock" {
+    const Test = struct {
+        fn incrementer(lock: *RwLock, value: *usize, check_value: *usize) !void {
+            try lock.lock();
+            defer lock.unlock();
+
+            value.* += 1000;
+
+            const stored = check_value.*;
+
+            // simulates a "workload" + makes coroutines to try lock
+            try coro.io.single(.timeout, .{ .ns = std.time.ns_per_ms });
+
+            check_value.* = stored + 1000;
+        }
+
+        fn checker(lock: *RwLock, value: *usize, check_value: *usize) !void {
+            while (true) {
+                // simulates a "workload"
+                try coro.io.single(.timeout, .{ .ns = 16 * std.time.ns_per_ms });
+
+                try lock.lockShared();
+                defer lock.unlockShared();
+
+                if (value.* == 1024000 and check_value.* == 1024000) break;
+            }
+        }
+
+        fn test_thread(lock: *RwLock, value: *usize, check_value: *usize) !void {
+            var scheduler = try coro.Scheduler.init(std.testing.allocator, .{});
+            defer scheduler.deinit();
+
+            for (0..128) |_| {
+                _ = try scheduler.spawn(incrementer, .{ lock, value, check_value }, .{ .detached = true });
+            }
+
+            for (0..16) |_| {
+                _ = try scheduler.spawn(checker, .{ lock, value, check_value }, .{ .detached = true });
+            }
+
+            try scheduler.run(.wait);
+        }
+    };
+
+    var lock = try RwLock.init();
+    defer lock.deinit();
+
+    var value: usize = 0;
+    var check_value: usize = 0;
+
+    var threads: [8]std.Thread = undefined;
+
+    for (0..8) |i| {
+        threads[i] = try std.Thread.spawn(.{}, Test.test_thread, .{ &lock, &value, &check_value });
+    }
+
+    for (threads) |thread| {
+        thread.join();
+    }
+
+    try std.testing.expectEqual(value, 1024000);
+    try std.testing.expectEqual(check_value, 1024000);
+}
+
+test "Mutex.Cancel" {
+    const Test = struct {
+        fn incrementer(lock: *Mutex, value: *usize, check_value: *usize) !void {
+            while (true) {
+                try lock.lock();
+                defer lock.unlock();
+
+                value.* += 1000;
+
+                const stored = check_value.*;
+
+                coro.io.single(.timeout, .{ .ns = std.time.ns_per_ms }) catch |err| switch (err) {
+                    error.Canceled => {},
+                    else => return err,
+                };
+
+                check_value.* = stored + 1000;
+            }
+        }
+
+        fn cancel(canceled: *bool) !void {
+            try coro.io.single(.timeout, .{ .ns = 16 * std.time.ns_per_ms });
+            canceled.* = true;
+        }
+
+        fn test_thread(lock: *Mutex, value: *usize, check_value: *usize) !void {
+            var scheduler = try coro.Scheduler.init(std.testing.allocator, .{});
+            defer scheduler.deinit();
+
+            for (0..128) |_| {
+                _ = try scheduler.spawn(incrementer, .{ lock, value, check_value }, .{ .detached = true });
+            }
+
+            var canceled = false;
+            _ = try scheduler.spawn(cancel, .{&canceled}, .{ .detached = true });
+
+            while (!canceled) {
+                _ = try scheduler.tick(.blocking);
+            }
+
+            try scheduler.run(.cancel);
+        }
+    };
+
+    var lock = try Mutex.init();
+    defer lock.deinit();
+
+    var value: usize = 0;
+    var check_value: usize = 0;
+
+    var threads: [8]std.Thread = undefined;
+
+    for (0..8) |i| {
+        threads[i] = try std.Thread.spawn(.{}, Test.test_thread, .{ &lock, &value, &check_value });
+    }
+
+    for (threads) |thread| {
+        thread.join();
+    }
+
+    try std.testing.expectEqual(value, check_value);
+}
+
+test "RwLock.Cancel" {
+    const Test = struct {
+        fn incrementer(lock: *RwLock, value: *usize, check_value: *usize) !void {
+            while (true) {
+                try lock.lock();
+                defer lock.unlock();
+
+                value.* += 1000;
+
+                const stored = check_value.*;
+
+                coro.io.single(.timeout, .{ .ns = std.time.ns_per_ms }) catch |err| switch (err) {
+                    error.Canceled => {},
+                    else => return err,
+                };
+
+                check_value.* = stored + 1000;
+            }
+        }
+
+        fn locksharer(lock: *RwLock) !void {
+            while (true) {
+                try lock.lockShared();
+                defer lock.unlockShared();
+
+                // simulates a "workload"
+                try coro.io.single(.timeout, .{ .ns = 16 * std.time.ns_per_ms });
+            }
+        }
+
+        fn cancel(canceled: *bool) !void {
+            try coro.io.single(.timeout, .{ .ns = 16 * std.time.ns_per_ms });
+            canceled.* = true;
+        }
+
+        fn test_thread(lock: *RwLock, value: *usize, check_value: *usize) !void {
+            var scheduler = try coro.Scheduler.init(std.testing.allocator, .{});
+            defer scheduler.deinit();
+
+            for (0..128) |_| {
+                _ = try scheduler.spawn(incrementer, .{ lock, value, check_value }, .{ .detached = true });
+            }
+
+            for (0..16) |_| {
+                _ = try scheduler.spawn(locksharer, .{lock}, .{ .detached = true });
+            }
+
+            var canceled = false;
+            _ = try scheduler.spawn(cancel, .{&canceled}, .{ .detached = true });
+
+            while (!canceled) {
+                _ = try scheduler.tick(.blocking);
+            }
+
+            try scheduler.run(.cancel);
+        }
+    };
+
+    var lock = try RwLock.init();
+    defer lock.deinit();
+
+    var value: usize = 0;
+    var check_value: usize = 0;
+
+    var threads: [8]std.Thread = undefined;
+
+    for (0..8) |i| {
+        threads[i] = try std.Thread.spawn(.{}, Test.test_thread, .{ &lock, &value, &check_value });
+    }
+
+    for (threads) |thread| {
+        thread.join();
+    }
+
+    try std.testing.expectEqual(value, check_value);
+}

--- a/src/coro/sync.zig
+++ b/src/coro/sync.zig
@@ -8,6 +8,7 @@ fn wakeupWaiters(list: *Frame.WaitList, status: anytype) void {
     }
 }
 
+/// Cooperatively scheduled thread unsafe Semaphore
 pub const Semaphore = struct {
     waiters: Frame.WaitList = .{},
     used: bool = false,
@@ -45,6 +46,7 @@ pub const Semaphore = struct {
     }
 };
 
+/// Cooperatively scheduled thread unsafe ResetEvent
 pub const ResetEvent = struct {
     waiters: Frame.WaitList = .{},
     is_set: bool = false,


### PR DESCRIPTION
Replaces #68 

I cleaned up the PR, and fixed the RwLock implementation.
Thanks for the initial code and tests @YiraSan 