### PR TITLE
a Queue implementation

### DIFF
--- a/src/coro/zefi.zig
+++ b/src/coro/zefi.zig
@@ -261,27 +261,27 @@ const Intel_SysV = struct {
 
     const assembly =
         std.fmt.comptimePrint(
-        \\.global {[symbol]s}
-        \\{[symbol]s}:
-        \\  pushq %rbx
-        \\  pushq %rbp
-        \\  pushq %r12
-        \\  pushq %r13
-        \\  pushq %r14
-        \\  pushq %r15
-        \\
-        \\  movq %rsp, (%rdi)
-        \\  movq (%rsi), %rsp
-        \\
-        \\  popq %r15
-        \\  popq %r14
-        \\  popq %r13
-        \\  popq %r12
-        \\  popq %rbp
-        \\  popq %rbx
-        \\
-        \\  retq
-    , .{ .symbol = symbol });
+            \\.global {[symbol]s}
+            \\{[symbol]s}:
+            \\  pushq %rbx
+            \\  pushq %rbp
+            \\  pushq %r12
+            \\  pushq %r13
+            \\  pushq %r14
+            \\  pushq %r15
+            \\
+            \\  movq %rsp, (%rdi)
+            \\  movq (%rsi), %rsp
+            \\
+            \\  popq %r15
+            \\  popq %r14
+            \\  popq %r13
+            \\  popq %r12
+            \\  popq %rbp
+            \\  popq %rbx
+            \\
+            \\  retq
+        , .{ .symbol = symbol });
 };
 
 const Arm_64 = struct {
@@ -300,35 +300,35 @@ const Arm_64 = struct {
 
     const assembly =
         std.fmt.comptimePrint(
-        \\.global {[symbol]s}
-        \\{[symbol]s}:
-        \\  stp lr, fp, [sp, #-20*8]!
-        \\  stp d8, d9, [sp, #2*8]
-        \\  stp d10, d11, [sp, #4*8]
-        \\  stp d12, d13, [sp, #6*8]
-        \\  stp d14, d15, [sp, #8*8]
-        \\  stp x19, x20, [sp, #10*8]
-        \\  stp x21, x22, [sp, #12*8]
-        \\  stp x23, x24, [sp, #14*8]
-        \\  stp x25, x26, [sp, #16*8]
-        \\  stp x27, x28, [sp, #18*8]
-        \\
-        \\  mov x9, sp
-        \\  str x9, [x0]
-        \\  ldr x9, [x1]
-        \\  mov sp, x9
-        \\
-        \\  ldp x27, x28, [sp, #18*8]
-        \\  ldp x25, x26, [sp, #16*8]
-        \\  ldp x23, x24, [sp, #14*8]
-        \\  ldp x21, x22, [sp, #12*8]
-        \\  ldp x19, x20, [sp, #10*8]
-        \\  ldp d14, d15, [sp, #8*8]
-        \\  ldp d12, d13, [sp, #6*8]
-        \\  ldp d10, d11, [sp, #4*8]
-        \\  ldp d8, d9, [sp, #2*8]
-        \\  ldp lr, fp, [sp], #20*8
-        \\
-        \\  ret
-    , .{ .symbol = symbol });
+            \\.global {[symbol]s}
+            \\{[symbol]s}:
+            \\  stp lr, fp, [sp, #-20*8]!
+            \\  stp d8, d9, [sp, #2*8]
+            \\  stp d10, d11, [sp, #4*8]
+            \\  stp d12, d13, [sp, #6*8]
+            \\  stp d14, d15, [sp, #8*8]
+            \\  stp x19, x20, [sp, #10*8]
+            \\  stp x21, x22, [sp, #12*8]
+            \\  stp x23, x24, [sp, #14*8]
+            \\  stp x25, x26, [sp, #16*8]
+            \\  stp x27, x28, [sp, #18*8]
+            \\
+            \\  mov x9, sp
+            \\  str x9, [x0]
+            \\  ldr x9, [x1]
+            \\  mov sp, x9
+            \\
+            \\  ldp x27, x28, [sp, #18*8]
+            \\  ldp x25, x26, [sp, #16*8]
+            \\  ldp x23, x24, [sp, #14*8]
+            \\  ldp x21, x22, [sp, #12*8]
+            \\  ldp x19, x20, [sp, #10*8]
+            \\  ldp d14, d15, [sp, #8*8]
+            \\  ldp d12, d13, [sp, #6*8]
+            \\  ldp d10, d11, [sp, #4*8]
+            \\  ldp d8, d9, [sp, #2*8]
+            \\  ldp lr, fp, [sp], #20*8
+            \\
+            \\  ret
+        , .{ .symbol = symbol });
 };


### PR DESCRIPTION
A multi-producer, multi-consumer queue for sending data between tasks, schedulers, and threads.
It supports various configurations: single-producer & multi-consumer, multi-producer & single-consumer, and single-producer & single-consumer.
Only one consumer receives each sent data, regardless of the number of consumers.

If this queue is okay I will then work on implementing a BroadcastQueue, this will pratically be the same thing, but all consumers (except the sender) will receives a copy of the sended data. 