### PR TITLE
coro: make sync primitives public

### DIFF
--- a/src/coro.zig
+++ b/src/coro.zig
@@ -27,6 +27,9 @@ pub const Task = @import("coro/Task.zig");
 const sync = @import("coro/sync.zig");
 pub const Semaphore = sync.Semaphore;
 pub const ResetEvent = sync.ResetEvent;
+pub const Mutex = sync.Mutex;
+pub const RwLock = sync.RwLock;
+pub const Queue = sync.Queue;
 
 // Aliases
 pub const current = Task.current;

--- a/src/coro/sync.zig
+++ b/src/coro/sync.zig
@@ -80,7 +80,7 @@ pub const ResetEvent = struct {
 
 /// A thread-safe Mutex implemented on top of aio.EventSource
 /// When the mutex is locked other tasks can still run
-const Mutex = struct {
+pub const Mutex = struct {
     native: std.Thread.Mutex = .{},
     semaphore: aio.EventSource,
 


### PR DESCRIPTION
Just noticed it wasn't possible to access sync primitives recently added.